### PR TITLE
Add gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*~
+*.swp
+*.o
+longmynd
+fake_read


### PR DESCRIPTION
Add .gitignore file, containing common temporary files, object files, and the binaries.

This'll prevent the above files from being accidentally committed to git.