### PR TITLE
Add README.md and Travis CI minimal build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+## Travis CI Configuration file
+
+# Use barebones Travis image
+language: c
+
+# Install dependencies
+before_install:
+  - sudo apt install libusb-1.0-0-dev
+addons:
+  apt:
+    update: true
+
+# Only grab latest git commit (no need for history)
+git:
+  depth: 1
+
+script:
+  - make

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Longmynd [![Build Status](https://travis-ci.org/myorangedragon/longmynd.svg?branch=master)](https://travis-ci.org/myorangedragon/longmynd)
+
+An Open Source Linux ATV Receiver.
+
+Copyright 2019 Heather Lomond
+
+## Dependencies
+
+    sudo apt-get install libusb-1.0-0-dev
+
+## Compile
+
+    make
+
+## Run
+
+_todo_
+
+## License
+
+    Longmynd is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    Longmynd is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with longmynd.  If not, see <https://www.gnu.org/licenses/>.


### PR DESCRIPTION
Add README.md file, see content below. Usage section still needs to be completed.

Also adds config files for Travis CI for basic automated compile check.

Current config depends on success (and any required correction) of #3 