### PR TITLE
ftdi_usb.c: Fix flow of function in case of error in previous braced scope.

### DIFF
--- a/ftdi_usb.c
+++ b/ftdi_usb.c
@@ -286,7 +286,7 @@ uint8_t ftdi_usb_init(uint8_t usb_bus, uint8_t usb_addr, uint16_t vid, uint16_t 
         if ((err==ERROR_NONE) && (usb_device_count==count)) {
             printf("ERROR: invalid USB bus/device number\n");
             err=ERROR_FTDI_USB_BAD_DEVICE_NUM;
-        } else {
+        } else if(err==ERROR_NONE) {
 
             /* now we check our one has the right VID and PID */
             usb_candidate_device=usb_device_list[usb_device_count];


### PR DESCRIPTION
Causes function to fall out if the previous braced scope sets the `err` var, as I believe was intended.

Was highlighted by the use of extra warning & optimisation flags, which reported:

`ftdi_usb.c: In function ‘ftdi_usb_init’:
ftdi_usb.c:292:49: warning: ‘usb_device_count’ may be used uninitialized in this function [-Wmaybe-uninitialized]
             usb_candidate_device=usb_device_list[usb_device_count]`

This commit also removes the warning.