### PR TITLE
Minor usability tweaks.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ LDFLAGS += -lusb-1.0
 
 all: ${BIN} fake_read
 
+debug: CFLAGS += -ggdb -fno-omit-frame-pointer
+debug: all
+
 fake_read:
 	@${CC} fake_read.c -o $@
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Copyright 2019 Heather Lomond
 
     sudo apt-get install libusb-1.0-0-dev
 
+To run longmynd without requiring root, unplug the minitiouner and then install the udev rules file with:
+
+    sudo cp minitiouner.rules /etc/udev/rules.d/
+
 ## Compile
 
     make

--- a/fifo.c
+++ b/fifo.c
@@ -143,7 +143,7 @@ uint8_t fifo_init(char *ts_fifo, char *status_fifo, bool ignore_ts_fifo) {
     fd_status_fifo = open(status_fifo, O_WRONLY); 
     if (err==ERROR_NONE) {
         if (fd_status_fifo<0) {
-        printf("ERROR: Failed to open ts fifo%s\n",status_fifo);
+        printf("ERROR: Failed to open status fifo %s\n",status_fifo);
         err=ERROR_OPEN_STATUS_FIFO;
         } else printf("      Status: opened status fifo ok\n");
     }

--- a/ftdi_usb.c
+++ b/ftdi_usb.c
@@ -239,7 +239,6 @@ uint8_t ftdi_usb_init(uint8_t usb_bus, uint8_t usb_addr, uint16_t vid, uint16_t 
 /* return : error code                                                                                */
 /* -------------------------------------------------------------------------------------------------- */
     uint8_t err=ERROR_NONE;
-    int ret;
     ssize_t count;
     libusb_device **usb_device_list;
     int error_code;
@@ -310,27 +309,24 @@ uint8_t ftdi_usb_init(uint8_t usb_bus, uint8_t usb_addr, uint16_t vid, uint16_t 
         /* importantly, we now free up the list */
         libusb_free_device_list(usb_device_list, 1);
     }
-    /* now we should have the device handle of the device we are going to us */
-    /* we have two interfaces on the ftdi device (0 and 1) */
-    /* so next we make sure we are the only people using this device and this */
-    if (libusb_kernel_driver_active(usb_device_handle, 0)) libusb_detach_kernel_driver(usb_device_handle, 0);
-    if (libusb_kernel_driver_active(usb_device_handle, 1)) libusb_detach_kernel_driver(usb_device_handle, 1);
 
-    /* finally we claim both interfaces as ours */
-    if ((ret=libusb_claim_interface(usb_device_handle, 0))<0) {
-        libusb_close(usb_device_handle);
-        libusb_exit(usb_context);
-    	printf("ERROR: Unable to claim interface\n");
-        return ERROR_FTDI_USB_CLAIM;
-    }
-    if ((ret=libusb_claim_interface(usb_device_handle, 1))<0) {
-        libusb_close(usb_device_handle);
-        libusb_exit(usb_context);
-    	printf("ERROR: Unable to claim interface\n");
-        return ERROR_FTDI_USB_CLAIM;
+    if (err==ERROR_NONE) {
+        /* now we should have the device handle of the device we are going to us */
+        /* we have two interfaces on the ftdi device (0 and 1) */
+        /* so next we make sure we are the only people using this device and this */
+        if (libusb_kernel_driver_active(usb_device_handle, 0)) libusb_detach_kernel_driver(usb_device_handle, 0);
+        if (libusb_kernel_driver_active(usb_device_handle, 1)) libusb_detach_kernel_driver(usb_device_handle, 1);
+
+        /* finally we claim both interfaces as ours */
+        if (libusb_claim_interface(usb_device_handle, 0)<0 || libusb_claim_interface(usb_device_handle, 1)<0) {
+            libusb_close(usb_device_handle);
+            libusb_exit(usb_context);
+        	printf("ERROR: Unable to claim interface\n");
+            err=ERROR_FTDI_USB_CLAIM;
+        }
     }
 
-    return ERROR_NONE;
+    return err;
 }
 
 /* -------------------------------------------------------------------------------------------------- */

--- a/main.c
+++ b/main.c
@@ -335,7 +335,8 @@ int main(int argc, char *argv[]) {
                     /* we turn on the LNA we want and turn the other off (if they exist) */
                     if (err==ERROR_NONE) err=stvvglna_init(NIM_INPUT_TOP,    (swap) ? STVVGLNA_OFF : STVVGLNA_ON,  &lna_ok);
                     if (err==ERROR_NONE) err=stvvglna_init(NIM_INPUT_BOTTOM, (swap) ? STVVGLNA_ON  : STVVGLNA_OFF, &lna_ok);
-                    if (err!=ERROR_NONE) printf("ERROR: failed to init a device\n");
+
+                    if (err!=ERROR_NONE) printf("ERROR: failed to init a device - is the NIM powered on?\n");
 
                     /* now start the whole thing scanning for the signal */
                     if (err==ERROR_NONE) {

--- a/main.c
+++ b/main.c
@@ -144,9 +144,9 @@ uint8_t process_command_line(int argc, char *argv[],
         param++;
     }
 
-    if (argc<3) {
+    if ((argc-param)<2) {
         err=ERROR_ARGS_INPUT;
-        printf("ERROR: Main Frequency and Main Symbol Rate missing.\n");
+        printf("ERROR: Main Frequency and Main Symbol Rate not found.\n");
     }
 
     if (err==ERROR_NONE) {

--- a/main.c
+++ b/main.c
@@ -144,34 +144,52 @@ uint8_t process_command_line(int argc, char *argv[],
         param++;
     }
 
-    *main_freq =(uint32_t)strtol(argv[param++],NULL,10);
-    *main_sr   =(uint32_t)strtol(argv[param  ],NULL,10);
+    if (argc<3) {
+        err=ERROR_ARGS_INPUT;
+        printf("ERROR: Main Frequency and Main Symbol Rate missing.\n");
+    }
 
-    if (*main_freq>2450000) {
-        err=ERROR_ARGS_INPUT;
-        printf("ERROR: Freq must be <= 2450 MHz\n");
-    } else if (*main_freq<144) {
-        err=ERROR_ARGS_INPUT;
-        printf("ERROR: Freq_must be >= 144 MHz\n");
-    } else if (*main_sr>27500) {
-        err=ERROR_ARGS_INPUT;
-        printf("ERROR: SR must be <= 27 Msymbols/s\n");
-    } else if (*main_sr<33) {
-        err=ERROR_ARGS_INPUT;
-        printf("ERROR: SR must be >= 33 Ksymbols/s\n");
-    } else if (main_ip_set && main_fifo_set) {
-        err=ERROR_ARGS_INPUT;
-        printf("ERROR: Cannot set main FIFO and Main IP address\n");
-    } else { /* err==ERROR_NONE */
-         printf("      Status: Main Frequency=%i KHz\n",*main_freq);
-         printf("              Main Symbol Rate=%i KSymbols/S\n",*main_sr);
-         if (!main_usb_set) printf("              Using First Minitiouner detected on USB\n");
-         else               printf("              USB bus/device=%i,%i\n",*main_usb_bus,*main_usb_addr);
-         if (!main_ip_set)  printf("              Main TS output to FIFO=%s\n",*main_ts_fifo);
-         else               printf("              Main TS output to IP=%s:%i\n",*main_ip_addr,*main_ip_port);
-         printf("              Main Status FIFO=%s\n",*main_status_fifo);
-         if (*swap)         printf("              NIM inputs are swapped (Main now refers to BOTTOM F-Type\n");
-         else               printf("              Main refers to TOP F-Type\n");
+    if (err==ERROR_NONE) {
+        *main_freq =(uint32_t)strtol(argv[param++],NULL,10);
+        if(*main_freq==0) {
+            err=ERROR_ARGS_INPUT;
+            printf("ERROR: Main Frequency not in a valid format.\n");
+        }
+
+        *main_sr   =(uint32_t)strtol(argv[param  ],NULL,10);
+        if(*main_sr==0) {
+            err=ERROR_ARGS_INPUT;
+            printf("ERROR: Main Symbol Rate not in a valid format.\n");
+        }
+    }
+
+    if (err==ERROR_NONE) {
+        if (*main_freq>2450000) {
+            err=ERROR_ARGS_INPUT;
+            printf("ERROR: Freq must be <= 2450 MHz\n");
+        } else if (*main_freq<144) {
+            err=ERROR_ARGS_INPUT;
+            printf("ERROR: Freq_must be >= 144 MHz\n");
+        } else if (*main_sr>27500) {
+            err=ERROR_ARGS_INPUT;
+            printf("ERROR: SR must be <= 27 Msymbols/s\n");
+        } else if (*main_sr<33) {
+            err=ERROR_ARGS_INPUT;
+            printf("ERROR: SR must be >= 33 Ksymbols/s\n");
+        } else if (main_ip_set && main_fifo_set) {
+            err=ERROR_ARGS_INPUT;
+            printf("ERROR: Cannot set main FIFO and Main IP address\n");
+        } else { /* err==ERROR_NONE */
+             printf("      Status: Main Frequency=%i KHz\n",*main_freq);
+             printf("              Main Symbol Rate=%i KSymbols/S\n",*main_sr);
+             if (!main_usb_set) printf("              Using First Minitiouner detected on USB\n");
+             else               printf("              USB bus/device=%i,%i\n",*main_usb_bus,*main_usb_addr);
+             if (!main_ip_set)  printf("              Main TS output to FIFO=%s\n",*main_ts_fifo);
+             else               printf("              Main TS output to IP=%s:%i\n",*main_ip_addr,*main_ip_port);
+             printf("              Main Status FIFO=%s\n",*main_status_fifo);
+             if (*swap)         printf("              NIM inputs are swapped (Main now refers to BOTTOM F-Type\n");
+             else               printf("              Main refers to TOP F-Type\n");
+        }
     }
 
     if (err!=ERROR_NONE) {

--- a/minitiouner.rules
+++ b/minitiouner.rules
@@ -1,0 +1,5 @@
+# Install with `sudo cp minitiouner.rules /etc/udev/rules.d/`
+#  then unplug and replug the minitiouner
+
+# Minitiouner uses FT2232H/D default VID/PID, but it's own product string.
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6010", ATTRS{product}=="USB <-> NIM tuner", MODE:="0666"


### PR DESCRIPTION
Let me know if there's any of these you're not sure of and I'll split them out.

- Added `make debug` target to Makefile that includes GDB debugging symbols in the output binary.
- Added error-handling of missing Frequency and Symbol Rate arguments (previously caused segfault.)
- Added note to user that "failed to init a device" may be due to the NIM not being powered.
- Added udev rules and installation instructions to allow use of longmynd without root privileges.