### PR TITLE
Add support for Minitiouner Express in the udev rules file.

### DIFF
--- a/minitiouner.rules
+++ b/minitiouner.rules
@@ -3,3 +3,5 @@
 
 # Minitiouner uses FT2232H/D default VID/PID, but it's own product string.
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6010", ATTRS{product}=="USB <-> NIM tuner", MODE:="0666"
+# Minitiouner Express uses different product string
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6010", ATTRS{product}=="MiniTiouner-Express", MODE:="0666"


### PR DESCRIPTION
Minitiouner Express uses a different USB Product String for some reason. Therefore the current udev rules file does not detect it, leading to errors when not running with sudo.

This change adds a line for the specific Product String used by Minitiouner Express, in addition to that used by Minitiouners.

Tested successfully by Adrian G8UGD.