### PR TITLE
Add -p option to enable and control RT5047A LNB Voltage Regulators

### DIFF
--- a/ftdi.c
+++ b/ftdi.c
@@ -49,12 +49,37 @@
 #define MSB_RISING_EDGE_CLOCK_BIT_IN    0x22
 #define MSB_FAILING_EDGE_CLOCK_BIT_IN   0x26
 
+/*
+FTDI GPIO Pins
+LSB
+ - AC0: NIM Reset
+ - AC1: TS2SYNC
+ - AC2: <unused>
+ - AC3: <unused>
+ - AC4: LNB Bias Enable
+ - AC5: <unused>
+ - AC6: <unused>
+ - AC7: LNB Bias Voltage Select
+MSB
+*/
+
+#define FTDI_GPIO_PINID_NIM_RESET  0
+#define FTDI_GPIO_PINID_TS2SYNC   1
+#define FTDI_GPIO_PINID_LNB_BIAS_ENABLE   4
+#define FTDI_GPIO_PINID_LNB_BIAS_VSEL   7
+
 /* -------------------------------------------------------------------------------------------------- */
 /* ----------------- GLOBALS ------------------------------------------------------------------------ */
 /* -------------------------------------------------------------------------------------------------- */
 
 static int num_bytes_to_send = 0;
 static uint8_t out_buffer[256];
+
+/* Default GPIO value 0x6f = 0b01101111 = LNB Bias Off, LNB Voltage 12V, NIM not reset */
+static uint8_t ftdi_gpio_value = 0x6f;
+
+/* Default GPIO direction 0xf1 = 0b11110001 = LNB pins, NIM Reset are outputs, TS2SYNC is input (0 for in and 1 for out) */
+static uint8_t ftdi_gpio_direction = 0xf1;
 
 /* -------------------------------------------------------------------------------------------------- */
 /* ----------------- ROUTINES ----------------------------------------------------------------------- */
@@ -410,6 +435,35 @@ uint8_t ftdi_i2c_write_reg8(uint8_t addr, uint8_t reg, uint8_t val) {
 }
 
 /* -------------------------------------------------------------------------------------------------- */
+uint8_t ftdi_gpio_write(uint8_t pin_id, bool pin_value)
+/* -------------------------------------------------------------------------------------------------- */
+/* write pin_value to the FTDI GPIO pin AC<pin_id>                                                    */
+/* -------------------------------------------------------------------------------------------------- */
+{
+    printf("Flow: GPIO Write: %d->%d\n", pin_id, (int)pin_value);
+
+    if(pin_value)
+    {
+        ftdi_gpio_value |= (1 << pin_id);
+    }
+    else
+    {
+        ftdi_gpio_value &= ~(1 << pin_id);
+    }
+
+    num_bytes_to_send = 0;
+    out_buffer[num_bytes_to_send++] = 0x82; /* aka. MPSSE_CMD_SET_DATA_BITS_HIGHBYTE */
+    out_buffer[num_bytes_to_send++] = ftdi_gpio_value;
+    out_buffer[num_bytes_to_send++] = ftdi_gpio_direction;
+
+    ftdi_usb_i2c_write(out_buffer, num_bytes_to_send);
+
+    num_bytes_to_send = 0;
+
+    return ERROR_NONE;
+}
+
+/* -------------------------------------------------------------------------------------------------- */
 uint8_t ftdi_nim_reset(void)
 /* -------------------------------------------------------------------------------------------------- */
 /* toggle the reset line on the nim                                                                    */
@@ -417,20 +471,10 @@ uint8_t ftdi_nim_reset(void)
 {
     printf("Flow: FTDI nim reset\n");
 
-    num_bytes_to_send = 0;
-
-    out_buffer[num_bytes_to_send++] = 0x82;
-    out_buffer[num_bytes_to_send++] = 0x6e; /* reset is LSB */
-    out_buffer[num_bytes_to_send++] = 0xf1;
-    ftdi_usb_i2c_write(out_buffer, num_bytes_to_send);
-    num_bytes_to_send = 0;
+    ftdi_gpio_write(FTDI_GPIO_PINID_NIM_RESET, 0);
     usleep(10000);
 
-    out_buffer[num_bytes_to_send++] = 0x82;
-    out_buffer[num_bytes_to_send++] = 0x6f;
-    out_buffer[num_bytes_to_send++] = 0xf1;
-    ftdi_usb_i2c_write(out_buffer, num_bytes_to_send);
-    num_bytes_to_send = 0;
+    ftdi_gpio_write(FTDI_GPIO_PINID_NIM_RESET, 1);
     usleep(10000);
 
     return ERROR_NONE;

--- a/ftdi.c
+++ b/ftdi.c
@@ -440,7 +440,7 @@ uint8_t ftdi_gpio_write(uint8_t pin_id, bool pin_value)
 /* write pin_value to the FTDI GPIO pin AC<pin_id>                                                    */
 /* -------------------------------------------------------------------------------------------------- */
 {
-    printf("Flow: GPIO Write: %d->%d\n", pin_id, (int)pin_value);
+    printf("Flow: FTDI GPIO Write: pin %d -> value %d\n", pin_id, (int)pin_value);
 
     if(pin_value)
     {
@@ -476,6 +476,31 @@ uint8_t ftdi_nim_reset(void)
 
     ftdi_gpio_write(FTDI_GPIO_PINID_NIM_RESET, 1);
     usleep(10000);
+
+    return ERROR_NONE;
+}
+
+/* -------------------------------------------------------------------------------------------------- */
+uint8_t ftdi_set_polarisation_supply(bool supply_enable, bool supply_horizontal)
+/* -------------------------------------------------------------------------------------------------- */
+/* Controls RT5047A LNB Power Supply IC, fitted to an additional board.                               */
+/* -------------------------------------------------------------------------------------------------- */
+{
+    if(supply_enable) {
+        /* Set Voltage */
+        if(supply_horizontal) {
+            ftdi_gpio_write(FTDI_GPIO_PINID_LNB_BIAS_VSEL, 1);
+        }
+        else {
+            ftdi_gpio_write(FTDI_GPIO_PINID_LNB_BIAS_VSEL, 0);
+        }
+        /* Then enable output */
+        ftdi_gpio_write(FTDI_GPIO_PINID_LNB_BIAS_ENABLE, 1);
+    }
+    else {
+        /* Disable output */
+        ftdi_gpio_write(FTDI_GPIO_PINID_LNB_BIAS_ENABLE, 0);
+    }
 
     return ERROR_NONE;
 }

--- a/ftdi.h
+++ b/ftdi.h
@@ -23,8 +23,10 @@
 #define FTDI_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 uint8_t ftdi_init(uint8_t, uint8_t);
+uint8_t ftdi_set_polarisation_supply(bool, bool);
 uint8_t ftdi_send_byte(uint8_t);
 uint8_t ftdi_read(uint8_t*,uint8_t*);
 uint8_t ftdi_read_highbyte(uint8_t*);

--- a/longmynd.1
+++ b/longmynd.1
@@ -5,7 +5,7 @@ longmynd \- Outputs transport streams from the Minitiouner DVB-S/S2 demodulator
 .B longmynd \fR[\fB\-u\fR \fIUSB_BUS USB_DEVICE\fR]
          [\fB\-i\fR \fIMAIN_IP_ADDR\fR  \fIMAIN_PORT\fR | \fB\-t\fR \fIMAIN_TS_FIFO\fR]
          [\fB\-I\fR \fISTATUS_IP_ADDR\fR  \fISTATUS_PORT\fR | \fB\-s\fR \fIMAIN_STATUS_FIFO\fR]
-         [\fB\-w\fR] [\fB\-b\fR]
+         [\fB\-w\fR] [\fB\-b\fR] [\fB\-p\fR \fIh\fR | \fB\-p\fR \fIv\fR]
       \fIMAIN_FREQ\fR \fIMAIN_SR\fR
 .IR 
 .SH DESCRIPTION
@@ -42,6 +42,11 @@ Default uses the TOP RF input for the Main TS stream.
 .BR \-b
 If selected, this option enables a tone audio output that will be present when DVB-S2 is being demodulated, and will increase in pitch for an increase in MER, to aid pointing.
 By default this option is disabled.
+.TP
+.BR \-p " " \fIh\fR " "| " "\-p " " \fIv\fR
+Controls and enables the LNB supply voltage output when an RT5047A LNB Voltage Regulator is fitted.
+"-p v" will set 13V output (Vertical Polarisation), "-p h" will set 18V output (Horizontal Polarisation).
+By default the RT5047A output is disabled.
 .TP
 .BR \fIMAIN_FREQ\fR
 specifies the starting frequency (in KHz) of the Main TS Stream search algorithm".

--- a/main.c
+++ b/main.c
@@ -201,12 +201,9 @@ uint8_t process_command_line(int argc, char *argv[], longmynd_config_t *config) 
         } else if (status_ip_set && status_fifo_set) {
             err=ERROR_ARGS_INPUT;
             printf("ERROR: Cannot set Status FIFO and Status IP address\n");
-        } else if (config->ts_use_ip && config->status_use_ip) {
-            /* Check ip/port conflict */
-            if((config->ts_ip_port == config->status_ip_port) && (0==strcmp(config->ts_ip_addr, config->status_ip_addr))) {
-                err=ERROR_ARGS_INPUT;
-                printf("ERROR: Cannot set Status IP & Port identical to TS IP & Port\n");
-            }
+        } else if (config->ts_use_ip && config->status_use_ip && (config->ts_ip_port == config->status_ip_port) && (0==strcmp(config->ts_ip_addr, config->status_ip_addr))) {
+            err=ERROR_ARGS_INPUT;
+            printf("ERROR: Cannot set Status IP & Port identical to TS IP & Port\n");
         } else { /* err==ERROR_NONE */
              printf("      Status: Main Frequency=%i KHz\n",config->freq_requested);
              printf("              Main Symbol Rate=%i KSymbols/s\n",config->sr_requested);

--- a/main.h
+++ b/main.h
@@ -82,6 +82,9 @@ typedef struct {
     char status_ip_addr[16];
     int status_ip_port;
 
+    bool polarisation_supply;
+    bool polarisation_horizontal; // false -> 13V, true -> 18V
+
     bool new;
     pthread_mutex_t mutex;
 } longmynd_config_t;


### PR DESCRIPTION
This pull request adds a '-p' option to longmynd for the control of RT5047A LNB Voltage Regulators, allowing LNB polarisation control.

eg. `longmynd ... -p h ...` will set FTDI GPIO AC7 -> High to switch the 5047A to 18V, and then enable the 5047 output.

- The control pins pinout are described here: [wiki.batc.org.uk/Serit_LNB_DC_supply](https://wiki.batc.org.uk/Serit_LNB_DC_supply)
- Voltage configuration is always done before enabling.
- If the flag is omitted then the 5047A is explicitly switched off (FTDI GPIO AC4 -> Low).
- 'h' / 'v' detection is case-insensitive (ie. '-p H' also works).

Included in this changeset is also a commit to fix a small logic bug where the configuration summary was not printed if both TS and FIFO used IP outputs.