### PR TITLE
Initialise thread error vars to avoid possible race condition & timestamp struct for output submodules to detect new status

### DIFF
--- a/main.c
+++ b/main.c
@@ -591,6 +591,7 @@ int main(int argc, char *argv[]) {
 
     thread_vars_t thread_vars_ts = {
         .main_err_ptr = &err,
+        .thread_err = ERROR_NONE,
         .config = &longmynd_config,
         .status = &longmynd_status
     };
@@ -606,6 +607,7 @@ int main(int argc, char *argv[]) {
 
     thread_vars_t thread_vars_ts_parse = {
         .main_err_ptr = &err,
+        .thread_err = ERROR_NONE,
         .config = &longmynd_config,
         .status = &longmynd_status
     };
@@ -621,6 +623,7 @@ int main(int argc, char *argv[]) {
 
     thread_vars_t thread_vars_i2c = {
         .main_err_ptr = &err,
+        .thread_err = ERROR_NONE,
         .config = &longmynd_config,
         .status = &longmynd_status
     };
@@ -636,6 +639,7 @@ int main(int argc, char *argv[]) {
 
     thread_vars_t thread_vars_beep = {
         .main_err_ptr = &err,
+        .thread_err = ERROR_NONE,
         .config = &longmynd_config,
         .status = &longmynd_status
     };

--- a/main.c
+++ b/main.c
@@ -66,7 +66,7 @@ static longmynd_config_t longmynd_config = {
 static longmynd_status_t longmynd_status = {
     .service_name = "\0",
     .service_provider_name = "\0",
-    .new = false,
+    .last_updated_monotonic = 0,
     .mutex = PTHREAD_MUTEX_INITIALIZER,
     .signal = PTHREAD_COND_INITIALIZER
 };
@@ -89,6 +89,22 @@ uint64_t timestamp_ms(void) {
     struct timespec tp;
 
     if(clock_gettime(CLOCK_REALTIME, &tp) != 0)
+    {
+        return 0;
+    }
+
+    return (uint64_t) tp.tv_sec * 1000 + tp.tv_nsec / 1000000;
+}
+
+/* -------------------------------------------------------------------------------------------------- */
+uint64_t monotonic_ms(void) {
+/* -------------------------------------------------------------------------------------------------- */
+/* Returns current value of a monotonic timer in milliseconds                                         */
+/* return: monotonic timer in milliseconds                                                            */
+/* -------------------------------------------------------------------------------------------------- */
+    struct timespec tp;
+
+    if(clock_gettime(CLOCK_MONOTONIC, &tp) != 0)
     {
         return 0;
     }
@@ -475,8 +491,8 @@ void *loop_i2c(void *arg) {
         status->short_frame = status_cpy.short_frame;
         status->pilots = status_cpy.pilots;
 
-        /* Set new data flag */
-        status->new = true;
+        /* Set monotonic value to signal new data */
+        status->last_updated_monotonic = monotonic_ms();
         /* Trigger pthread signal */
         pthread_cond_signal(&status->signal);
         pthread_mutex_unlock(&status->mutex);
@@ -633,21 +649,24 @@ int main(int argc, char *argv[]) {
         pthread_setname_np(thread_beep, "Beep Audio");
     }
 
+    uint64_t last_status_sent_monotonic = 0;
     longmynd_status_t longmynd_status_cpy;
 
     while (err==ERROR_NONE) {
         /* Test if new status data is available */
-        if(longmynd_status.new) {
-            /* Acquire lock on status struct */
+        if(longmynd_status.last_updated_monotonic != last_status_sent_monotonic) {
+            /* Acquire lock on global status struct */
             pthread_mutex_lock(&longmynd_status.mutex);
             /* Clone status struct locally */
             memcpy(&longmynd_status_cpy, &longmynd_status, sizeof(longmynd_status_t));
-            /* Clear new flag on status struct */
-            longmynd_status.new = false;
+            /* Release lock on global status struct */
             pthread_mutex_unlock(&longmynd_status.mutex);
 
             /* Send all status via configured output interface from local copy */
             err=status_all_write(&longmynd_status_cpy, status_write, status_string_write);
+
+            /* Update monotonic timestamp last sent */
+            last_status_sent_monotonic = longmynd_status_cpy.last_updated_monotonic;
         } else {
             /* Sleep 10ms */
             usleep(10*1000);

--- a/main.h
+++ b/main.h
@@ -112,7 +112,7 @@ typedef struct {
     bool short_frame;
     bool pilots;
 
-    bool new;
+    uint64_t last_updated_monotonic;
     pthread_mutex_t mutex;
     pthread_cond_t signal;
 } longmynd_status_t;


### PR DESCRIPTION
 - Initialise thread error variables to ERROR_NONE before starting threads, to prevent possible undefined behaviour if the main loop checks the variables before the threads themselves have set them to ERROR_NONE.

 - Use monotonic timer to timestamp the status struct, allowing a scalable number of output submodules to detect new changes without adding to the main struct.