### PR TITLE
Use MER valid flag to decide whether MER is valid, for -S & -S2

### DIFF
--- a/main.c
+++ b/main.c
@@ -293,8 +293,8 @@ uint8_t do_report(longmynd_status_t *status) {
     if (err==ERROR_NONE) err=stv0910_read_ber(STV0910_DEMOD_TOP, &status->bit_error_rate);
 
     /* MER */
-    if(status->state==STATE_DEMOD_S2) {
-        if (err==ERROR_NONE) err=stv0910_read_dvbs2_mer(STV0910_DEMOD_TOP, &status->modulation_error_rate);
+    if(status->state==STATE_DEMOD_S || status->state==STATE_DEMOD_S2) {
+        if (err==ERROR_NONE) err=stv0910_read_mer(STV0910_DEMOD_TOP, &status->modulation_error_rate);
     } else {
         status->modulation_error_rate = 0;
     }

--- a/stv0910.c
+++ b/stv0910.c
@@ -226,7 +226,7 @@ uint8_t stv0910_read_ber(uint8_t demod, uint32_t *ber) {
 }
 
 /* -------------------------------------------------------------------------------------------------- */
-uint8_t stv0910_read_dvbs2_mer(uint8_t demod, uint32_t *mer) {
+uint8_t stv0910_read_mer(uint8_t demod, uint32_t *mer) {
 /* -------------------------------------------------------------------------------------------------- */
 /*    demod: STV0910_DEMOD_TOP | STV0910_DEMOD_BOTTOM: which demodulator is being read                */
 /*      mer: place to store the result                                                                */
@@ -237,7 +237,17 @@ uint8_t stv0910_read_dvbs2_mer(uint8_t demod, uint32_t *mer) {
 
                          err=stv0910_read_reg(demod==STV0910_DEMOD_TOP ? RSTV0910_P2_NOSRAMPOS : RSTV0910_P1_NOSRAMPOS, &high);
     if (err==ERROR_NONE) err=stv0910_read_reg(demod==STV0910_DEMOD_TOP ? RSTV0910_P2_NOSRAMVAL : RSTV0910_P1_NOSRAMVAL, &low);
-    *mer = ((high & 0x03) << 8) | low;
+    
+    if(((high >> 2) & 0x01) == 1)
+    {
+        /* Px_NOSRAM_CNRVAL is valid */
+        *mer = ((high & 0x03) << 8) | low;
+    }
+    else
+    {
+        *mer = 0;
+        if (err==ERROR_NONE) err=stv0910_write_reg_field(demod==STV0910_DEMOD_TOP ? FSTV0910_P2_NOSRAM_ACTIVATION : FSTV0910_P1_NOSRAM_ACTIVATION, 0x02);
+    }
 
     if (err!=ERROR_NONE) printf("ERROR: STV0910 read DVBS2 MER\n");
 

--- a/stv0910.h
+++ b/stv0910.h
@@ -50,7 +50,7 @@ uint8_t stv0910_read_puncture_rate(uint8_t, uint8_t*);
 uint8_t stv0910_read_power(uint8_t, uint8_t*, uint8_t*);
 uint8_t stv0910_read_err_rate(uint8_t, uint32_t*);
 uint8_t stv0910_read_ber(uint8_t, uint32_t*);
-uint8_t stv0910_read_dvbs2_mer(uint8_t, uint32_t*);
+uint8_t stv0910_read_mer(uint8_t, uint32_t*);
 uint8_t stv0910_read_modcod_and_type(uint8_t, uint32_t*, bool*, bool*);
 uint8_t stv0910_init(uint32_t, uint32_t);
 uint8_t stv0910_init_regs(void);


### PR DESCRIPTION
For both protocols this uses Px_NOSRAM_VALIDE flag to decide whether the MER value in Px_NOSRAM_CNRVAL is valid or not, rather than deciding based on the protocol.