### PR TITLE
Fix TS fifo path argument parsing (-t)

### DIFF
--- a/main.c
+++ b/main.c
@@ -207,7 +207,7 @@ uint8_t process_command_line(int argc, char *argv[], longmynd_config_t *config) 
                 ts_ip_set = true;
                 break;
             case 't':
-                strncpy(config->status_fifo_path, argv[param], 128);
+                strncpy(config->ts_fifo_path, argv[param], 128);
                 ts_fifo_set=true;
                 break;
             case 'I':


### PR DESCRIPTION
Fix command line argument parsing to use supplied TS FIFO path rather than the default