### PR TITLE
Don't block on pthread mutex in ts data shuttling, closes #20

### DIFF
--- a/ts.c
+++ b/ts.c
@@ -109,10 +109,10 @@ void *loop_ts(void *arg) {
         if ((*err==ERROR_NONE) && (len>2)) {
             ts_write(&buffer[2],len-2);
 
-            if(longmynd_ts_parse_buffer.waiting && longmynd_ts_parse_buffer.buffer != NULL)
-            {                
-                pthread_mutex_lock(&longmynd_ts_parse_buffer.mutex);
-
+            if(longmynd_ts_parse_buffer.waiting
+            	&& longmynd_ts_parse_buffer.buffer != NULL
+            	&& pthread_mutex_trylock(&longmynd_ts_parse_buffer.mutex) == 0)
+            {
                 memcpy(longmynd_ts_parse_buffer.buffer, &buffer[2],len-2);
                 longmynd_ts_parse_buffer.length = len-2;
                 pthread_cond_signal(&longmynd_ts_parse_buffer.signal);


### PR DESCRIPTION
Thanks @dbrooke for the bisect.

Apologies for this problem had existing so long, the QO-100 beacon encoder corruption had hidden the symptoms.